### PR TITLE
handle multi session bids and run## vs run-## formatting plus crashdump location

### DIFF
--- a/subject_level/fmri_ants_bids.py
+++ b/subject_level/fmri_ants_bids.py
@@ -1211,6 +1211,7 @@ if __name__ == '__main__':
     if args.plugin_args:
         wf.run(args.plugin, plugin_args=eval(args.plugin_args))
     else:
+        #wf.run('SLURM', plugin_args={'sbatch_args': '-p om_interactive -N1 -c1','max_jobs':40}) 
         wf.run(args.plugin)
 
 


### PR DESCRIPTION
Please check line 702 in the new file.  I think this line breaks compatibility with non multi session runs and would improperly handle multiple subjects with different sessions (e.g. sub999 ses1, sub998 ses2).  It's also unclear if one call of the script would work correctly across multiple subjects with multiple sessions (sub999 ses1 and sub999 ses2 might both get processed as sub999 ses1).

However, the script was successfully run on one subject, one session, one task.
