### PR TITLE
change pickfirst lambda functions fmri_ants_bids.py

### DIFF
--- a/subject_level/fmri_ants_bids.py
+++ b/subject_level/fmri_ants_bids.py
@@ -237,7 +237,7 @@ def create_reg_workflow(name='registration'):
     """
 
     #pickfirst = lambda x: x[0]
-     pickfirst = lambda x: x[0] if isinstance(x, (list, tuple)) else x
+    pickfirst = lambda x: x[0] if isinstance(x, (list, tuple)) else x
 	
 
     merge = pe.Node(niu.Merge(2), iterfield=['in2'], name='mergexfm')
@@ -456,7 +456,7 @@ def create_fs_reg_workflow(name='registration'):
     """
 
     #pickfirst = lambda x: x[0]
-     pickfirst = lambda x: x[0] if isinstance(x, (list, tuple)) else x
+    pickfirst = lambda x: x[0] if isinstance(x, (list, tuple)) else x
 	
 
     merge = Node(Merge(2), iterfield=['in2'], name='mergexfm')

--- a/subject_level/fmri_ants_bids.py
+++ b/subject_level/fmri_ants_bids.py
@@ -236,7 +236,9 @@ def create_reg_workflow(name='registration'):
     Concatenate the affine and ants transforms into a list
     """
 
-    pickfirst = lambda x: x[0]
+    #pickfirst = lambda x: x[0]
+     pickfirst = lambda x: x[0] if isinstance(x, (list, tuple)) else x
+	
 
     merge = pe.Node(niu.Merge(2), iterfield=['in2'], name='mergexfm')
     register.connect(convert2itk, 'itk_transform', merge, 'in2')
@@ -453,7 +455,9 @@ def create_fs_reg_workflow(name='registration'):
     Concatenate the affine and ants transforms into a list
     """
 
-    pickfirst = lambda x: x[0]
+    #pickfirst = lambda x: x[0]
+     pickfirst = lambda x: x[0] if isinstance(x, (list, tuple)) else x
+	
 
     merge = Node(Merge(2), iterfield=['in2'], name='mergexfm')
     register.connect(convert2itk, 'itk_transform', merge, 'in2')


### PR DESCRIPTION
attempt at making `pickfirst = lambda x: x[0]` less error prone, currently if a string is used as input then it would just select the first character which later results in an error (most likely about file paths). 